### PR TITLE
changed  : `mul` to `multiply` because the TF documentation says "dep…

### DIFF
--- a/tensorflow_basics.md
+++ b/tensorflow_basics.md
@@ -77,7 +77,7 @@ b = tf.placeholder(tf.types.int16)
 
 ```python
 add = tf.add(a, b)
-mul = tf.mul(a, b)
+mul = tf.multiply(a, b)
 ```
 
 


### PR DESCRIPTION
…recated"

In line 80 changed `tf.mul` with `tf.multiply` because in the latest version of TF it is  "deprecated" and giving this error while running the program https://stackoverflow.com/questions/42217059/tensorflowattributeerror-module-object-has-no-attribute-mul